### PR TITLE
問合せ項目を設定画面に追加

### DIFF
--- a/app/assets/i18n/en.i18n.json
+++ b/app/assets/i18n/en.i18n.json
@@ -5,7 +5,11 @@
     "language": "Language",
     "theme": "Theme",
     "version": "Version",
-    "licenses": "Licenses"
+    "licenses": "Licenses",
+    "aboutXinxin": "About XINXIN",
+    "aboutXinxinSubtitle": "Please check the official X for details",
+    "inquiry": "Inquiries about this site",
+    "inquirySubtitle": "Please contact @r0227n for opinions, requests, questions, etc."
   },
   "dialog": {
     "close": "Close",

--- a/app/assets/i18n/ja.i18n.json
+++ b/app/assets/i18n/ja.i18n.json
@@ -5,7 +5,11 @@
     "language": "言語",
     "theme": "テーマ",
     "version": "バージョン",
-    "licenses": "ライセンス"
+    "licenses": "ライセンス",
+    "aboutXinxin": "XINXINとは？",
+    "aboutXinxinSubtitle": "詳細は公式Xをご覧ください",
+    "inquiry": "本サイトに対するお問い合わせ",
+    "inquirySubtitle": "ご意見・ご要望・ご質問などは@r0227nへご連絡ください"
   },
   "dialog": {
     "close": "閉じる",

--- a/app/lib/i18n/translations.g.dart
+++ b/app/lib/i18n/translations.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 42 (21 per locale)
+/// Strings: 50 (25 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/lib/i18n/translations_en.g.dart
+++ b/app/lib/i18n/translations_en.g.dart
@@ -76,6 +76,15 @@ class _TranslationsSettingsEn implements TranslationsSettingsJa {
   String get version => 'Version';
   @override
   String get licenses => 'Licenses';
+  @override
+  String get aboutXinxin => 'About XINXIN';
+  @override
+  String get aboutXinxinSubtitle => 'Please check the official X for details';
+  @override
+  String get inquiry => 'Inquiries about this site';
+  @override
+  String get inquirySubtitle =>
+      'Please contact @r0227n for opinions, requests, questions, etc.';
 }
 
 // Path: dialog

--- a/app/lib/i18n/translations_ja.g.dart
+++ b/app/lib/i18n/translations_ja.g.dart
@@ -68,6 +68,10 @@ class TranslationsSettingsJa {
   String get theme => 'テーマ';
   String get version => 'バージョン';
   String get licenses => 'ライセンス';
+  String get aboutXinxin => 'XINXINとは？';
+  String get aboutXinxinSubtitle => '詳細は公式Xをご覧ください';
+  String get inquiry => '本サイトに対するお問い合わせ';
+  String get inquirySubtitle => 'ご意見・ご要望・ご質問などは@r0227nへご連絡ください';
 }
 
 // Path: dialog

--- a/app/lib/pages/settings/settings_page.dart
+++ b/app/lib/pages/settings/settings_page.dart
@@ -6,6 +6,34 @@ import 'package:app_preferences/app_preferences.dart' as app_prefs;
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+class ListItem {
+  const ListItem({
+    required Widget title,
+    Widget? subtitle,
+    Widget? trailing,
+    GestureTapCallback? onTap,
+  }) : _title = title,
+       _subtitle = subtitle,
+       _trailing = trailing,
+       _onTap = onTap;
+
+  final Widget _title;
+  final Widget? _subtitle;
+  final Widget? _trailing;
+  final GestureTapCallback? _onTap;
+
+  static Icon get iconChervon => const Icon(Icons.chevron_right);
+
+  ListTile toListTile() {
+    return ListTile(
+      title: _title,
+      subtitle: _subtitle,
+      trailing: _trailing,
+      onTap: _onTap,
+    );
+  }
+}
+
 class SettingsPage extends ConsumerWidget {
   const SettingsPage({super.key});
 
@@ -13,43 +41,43 @@ class SettingsPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final t = Translations.of(context);
 
-    // TranslationProvider is now available as:
-    // app_prefs.TranslationProvider
+    final children = [
+      ListItem(
+        title: Text(t.settings.language),
+        subtitle: const app_prefs.LocaleText(),
+        trailing: ListItem.iconChervon,
+        onTap: () => _showLanguageDialog(context, t),
+      ),
+      ListItem(
+        title: Text(t.settings.theme),
+        subtitle: const app_prefs.ThemeText(),
+        trailing: ListItem.iconChervon,
+        onTap: () => _showThemeDialog(context, t),
+      ),
+      ListItem(
+        title: Text(t.settings.version),
+        subtitle: const app_prefs.VersionText(),
+        trailing: const Icon(Icons.info_outline),
+        // Version is display-only
+      ),
+      ListItem(
+        title: Text(t.settings.licenses),
+        trailing: ListItem.iconChervon,
+        onTap: () => const LicenseRoute().go(context),
+      ),
+    ];
 
     return Scaffold(
       appBar: AppBar(
         title: Text(t.settings.title),
       ),
-      body: ListView(
-        children: [
-          ListTile(
-            title: Text(t.settings.language),
-            subtitle: const app_prefs.LocaleText(),
-            trailing: const Icon(Icons.chevron_right),
-            onTap: () => _showLanguageDialog(context, t),
-          ),
-          const Divider(),
-          ListTile(
-            title: Text(t.settings.theme),
-            subtitle: const app_prefs.ThemeText(),
-            trailing: const Icon(Icons.chevron_right),
-            onTap: () => _showThemeDialog(context, t),
-          ),
-          const Divider(),
-          ListTile(
-            title: Text(t.settings.version),
-            subtitle: const app_prefs.VersionText(),
-            trailing: const Icon(Icons.info_outline),
-            // Version is display-only
-          ),
-          const Divider(),
-          ListTile(
-            title: Text(t.settings.licenses),
-            trailing: const Icon(Icons.chevron_right),
-            onTap: () => const LicenseRoute().go(context),
-          ),
-          const Divider(),
-        ],
+      body: ListView.separated(
+        itemBuilder: (context, indext) {
+          final item = children[indext];
+          return item.toListTile();
+        },
+        separatorBuilder: (context, index) => const Divider(),
+        itemCount: children.length,
       ),
     );
   }

--- a/app/lib/pages/settings/settings_page.dart
+++ b/app/lib/pages/settings/settings_page.dart
@@ -5,6 +5,7 @@ import 'package:app/router/routes.dart';
 import 'package:app_preferences/app_preferences.dart' as app_prefs;
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class ListItem {
   const ListItem({
@@ -23,6 +24,8 @@ class ListItem {
   final GestureTapCallback? _onTap;
 
   static Icon get iconChervon => const Icon(Icons.chevron_right);
+
+  static Icon get iconOpenBrowser => const Icon(Icons.open_in_new);
 
   ListTile toListTile() {
     return ListTile(
@@ -55,10 +58,21 @@ class SettingsPage extends ConsumerWidget {
         onTap: () => _showThemeDialog(context, t),
       ),
       ListItem(
+        title: Text(t.settings.aboutXinxin),
+        subtitle: Text(t.settings.aboutXinxinSubtitle),
+        trailing: ListItem.iconOpenBrowser,
+        onTap: () => launchUrl(Uri.parse('https://x.com/xinxin_official')),
+      ),
+      ListItem(
+        title: Text(t.settings.inquiry),
+        subtitle: Text(t.settings.inquirySubtitle),
+        trailing: ListItem.iconOpenBrowser,
+        onTap: () => launchUrl(Uri.parse('https://x.com/r0227n')),
+      ),
+      ListItem(
         title: Text(t.settings.version),
         subtitle: const app_prefs.VersionText(),
         trailing: const Icon(Icons.info_outline),
-        // Version is display-only
       ),
       ListItem(
         title: Text(t.settings.licenses),

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   slang_flutter: ^4.7.0
   talker_flutter: ^4.9.2
   talker_riverpod_logger: ^4.9.2
+  url_launcher: ^6.3.2
   web: ^1.1.1
   youtube_player_iframe: ^5.2.2
 


### PR DESCRIPTION
## 📝 概要

<!-- このPRで何を実装したか、簡潔に教えてください -->

## 🔄 変更内容

<!-- どんな変更を行ったか、箇条書きで記載してください -->

-
-
-

## 🔗 関連Issue

- Closes #<!-- Issue番号があれば記載 -->

## ✅ 基本チェック

### 動作確認

- [ ] 機能が期待通り動作する
- [ ] エラーが発生しない
- [ ] 既存機能に影響がない

### コード品質

- [ ] `melos run analyze` でエラーなし
- [ ] `melos run format` を実行済み
- [ ] テストを追加・更新（必要に応じて）

## 📱 テスト結果

<!-- 実際にテストした内容を記載してください -->

- [ ] iOSで動作確認
- [ ] Androidで動作確認

## 🖼️ スクリーンショット（UI変更がある場合）

<!-- 変更前後の画面があれば貼り付けてください -->

## 💬 レビュアーへのメモ

<!-- 特に見てほしいポイントや注意事項があれば記載してください -->

---

**🚀 Ready for review!**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 設定に「XINXINとは？」「お問い合わせ」を追加。タップで外部ブラウザから公式Xや連絡先を開けます。
- ローカライズ
  - 日英の文言を追加し、設定項目の翻訳を拡充。
- リファクタ
  - 設定画面のリスト構成を整理し、区切り線付きの一覧表示に改善。各項目のタップ動作を明確化。
- 雑務
  - 外部URL起動のための依存関係を追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->