### PR TITLE
セットリスト詳細画面を実装

### DIFF
--- a/app/assets/i18n/en.i18n.json
+++ b/app/assets/i18n/en.i18n.json
@@ -17,6 +17,16 @@
   },
   "setlist": {
     "title": "XINXIN SETLIST",
+    "detail": {
+      "title": "Setlist Detail",
+      "eventInfo": "Event Information",
+      "eventTitle": "Event Title",
+      "eventOrder": "Event Order",
+      "venue": "Venue",
+      "musicList": "Music List",
+      "musicNumber": "$number number",
+      "musicCount": "$count songs"
+    },
     "error": {
       "bothIdsSpecified": "Cannot specify both eventId and musicId simultaneously",
       "occurred": "An error occurred",

--- a/app/assets/i18n/ja.i18n.json
+++ b/app/assets/i18n/ja.i18n.json
@@ -17,6 +17,16 @@
   },
   "setlist": {
     "title": "XINXIN SETLIST",
+    "detail": {
+      "title": "セットリスト詳細",
+      "eventInfo": "イベント情報",
+      "eventTitle": "イベント名",
+      "eventOrder": "開催順",
+      "venue": "会場",
+      "musicList": "楽曲リスト",
+      "musicNumber": "$number 曲目",
+      "musicCount": "$count 曲"
+    },
     "error": {
       "bothIdsSpecified": "eventIdとmusicIdの両方を同時に指定することはできません",
       "occurred": "エラーが発生しました",

--- a/app/lib/data/repositories/stage_repository.dart
+++ b/app/lib/data/repositories/stage_repository.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:app/data/repositories/event_repository.dart';
 import 'package:app_logger/app_logger.dart';
 import 'package:cores/cores.dart';
 import 'package:flutter/services.dart';
@@ -21,7 +22,11 @@ class StageRepository extends _$StageRepository with LoggerMixin {
 
   /// イベントIDからステージを取得する
   Future<Stage?> getFromEventId(String eventId) async {
-    final stages = await ref.read(stageRepositoryProvider.future);
-    return stages.where((stage) => stage.id == eventId).firstOrNull;
+    final (stages, event) = await (
+      future,
+      ref.read(eventRepositoryProvider.notifier).get(eventId),
+    ).wait;
+
+    return stages.where((stage) => stage.id == event.stageId).firstOrNull;
   }
 }

--- a/app/lib/data/repositories/stage_repository.dart
+++ b/app/lib/data/repositories/stage_repository.dart
@@ -18,4 +18,10 @@ class StageRepository extends _$StageRepository with LoggerMixin {
         .map((e) => Stage.fromJson(e as Map<String, dynamic>))
         .toList();
   }
+
+  /// イベントIDからステージを取得する
+  Future<Stage?> getFromEventId(String eventId) async {
+    final stages = await ref.read(stageRepositoryProvider.future);
+    return stages.where((stage) => stage.id == eventId).firstOrNull;
+  }
 }

--- a/app/lib/data/repositories/stage_repository.g.dart
+++ b/app/lib/data/repositories/stage_repository.g.dart
@@ -6,7 +6,7 @@ part of 'stage_repository.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$stageRepositoryHash() => r'e443996e4e7f3a55930342618242b0180264106f';
+String _$stageRepositoryHash() => r'5f510c7ec3f16cf51122eb8df8c6450c6b413054';
 
 /// See also [StageRepository].
 @ProviderFor(StageRepository)

--- a/app/lib/i18n/translations.g.dart
+++ b/app/lib/i18n/translations.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 50 (25 per locale)
+/// Strings: 66 (33 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import
@@ -137,7 +137,11 @@ extension BuildContextTranslationsExtension on BuildContext {
 /// Manages all translation instances and the current locale
 class LocaleSettings
     extends BaseFlutterLocaleSettings<AppLocale, Translations> {
-  LocaleSettings._() : super(utils: AppLocaleUtils.instance, lazy: true);
+  LocaleSettings._()
+    : super(
+        utils: AppLocaleUtils.instance,
+        lazy: true,
+      );
 
   static final instance = LocaleSettings._();
 
@@ -200,7 +204,10 @@ class LocaleSettings
 /// Provides utility functions without any side effects.
 class AppLocaleUtils extends BaseAppLocaleUtils<AppLocale, Translations> {
   AppLocaleUtils._()
-    : super(baseLocale: AppLocale.ja, locales: AppLocale.values);
+    : super(
+        baseLocale: AppLocale.ja,
+        locales: AppLocale.values,
+      );
 
   static final instance = AppLocaleUtils._();
 

--- a/app/lib/i18n/translations_en.g.dart
+++ b/app/lib/i18n/translations_en.g.dart
@@ -110,6 +110,9 @@ class _TranslationsSetlistEn implements TranslationsSetlistJa {
   @override
   String get title => 'XINXIN SETLIST';
   @override
+  late final _TranslationsSetlistDetailEn detail =
+      _TranslationsSetlistDetailEn._(_root);
+  @override
   late final _TranslationsSetlistErrorEn error = _TranslationsSetlistErrorEn._(
     _root,
   );
@@ -136,6 +139,31 @@ class _TranslationsMusicEn implements TranslationsMusicJa {
   // Translations
   @override
   String get detail => 'Music Detail';
+}
+
+// Path: setlist.detail
+class _TranslationsSetlistDetailEn implements TranslationsSetlistDetailJa {
+  _TranslationsSetlistDetailEn._(this._root);
+
+  final TranslationsEn _root; // ignore: unused_field
+
+  // Translations
+  @override
+  String get title => 'Setlist Detail';
+  @override
+  String get eventInfo => 'Event Information';
+  @override
+  String get eventTitle => 'Event Title';
+  @override
+  String get eventOrder => 'Event Order';
+  @override
+  String get venue => 'Venue';
+  @override
+  String get musicList => 'Music List';
+  @override
+  String musicNumber({required Object number}) => '${number} number';
+  @override
+  String musicCount({required Object count}) => '${count} songs';
 }
 
 // Path: setlist.error

--- a/app/lib/i18n/translations_ja.g.dart
+++ b/app/lib/i18n/translations_ja.g.dart
@@ -93,6 +93,9 @@ class TranslationsSetlistJa {
 
   // Translations
   String get title => 'XINXIN SETLIST';
+  late final TranslationsSetlistDetailJa detail = TranslationsSetlistDetailJa._(
+    _root,
+  );
   late final TranslationsSetlistErrorJa error = TranslationsSetlistErrorJa._(
     _root,
   );
@@ -113,6 +116,23 @@ class TranslationsMusicJa {
 
   // Translations
   String get detail => '楽曲詳細';
+}
+
+// Path: setlist.detail
+class TranslationsSetlistDetailJa {
+  TranslationsSetlistDetailJa._(this._root);
+
+  final Translations _root; // ignore: unused_field
+
+  // Translations
+  String get title => 'セットリスト詳細';
+  String get eventInfo => 'イベント情報';
+  String get eventTitle => 'イベント名';
+  String get eventOrder => '開催順';
+  String get venue => '会場';
+  String get musicList => '楽曲リスト';
+  String musicNumber({required Object number}) => '${number} 曲目';
+  String musicCount({required Object count}) => '${count} 曲';
 }
 
 // Path: setlist.error

--- a/app/lib/pages/setlist_detail_page.dart
+++ b/app/lib/pages/setlist_detail_page.dart
@@ -1,0 +1,412 @@
+import 'package:app/data/repositories/event_repository.dart';
+import 'package:app/data/repositories/music_repository.dart';
+import 'package:app/data/repositories/stage_repository.dart';
+import 'package:app/data/services/setlist_service.dart';
+import 'package:app/i18n/translations.g.dart';
+import 'package:app/router/routes.dart';
+import 'package:app_logger/app_logger.dart';
+import 'package:app_preferences/app_preferences.dart';
+import 'package:cores/cores.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// セットリスト詳細データ
+typedef SetlistDetail = (Setlist, Event, Stage?);
+
+/// セットリスト詳細表示ページ
+///
+/// 指定された[eventId]のセットリストを詳細表示する
+class SetlistDetailPage extends ConsumerStatefulWidget {
+  const SetlistDetailPage({
+    required this.eventId,
+    super.key,
+  });
+
+  /// 表示するセットリストのイベントID
+  final String eventId;
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(StringProperty('eventId', eventId));
+  }
+
+  @override
+  ConsumerState<SetlistDetailPage> createState() => _SetlistDetailPageState();
+}
+
+class _SetlistDetailPageState extends ConsumerState<SetlistDetailPage>
+    with LoggerMixin {
+  late final Future<SetlistDetail> _setlistDetailAsync;
+
+  @override
+  void initState() {
+    super.initState();
+    _setlistDetailAsync = (
+      ref.read(setlistServiceProvider).getSetlist(widget.eventId),
+      ref.read(eventRepositoryProvider.notifier).get(widget.eventId),
+      ref.read(stageRepositoryProvider.notifier).getFromEventId(widget.eventId),
+    ).wait;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        actions: [
+          IconButton(
+            onPressed: () => const SettingsRoute().go(context),
+            icon: const Icon(Icons.settings),
+          ),
+        ],
+      ),
+      body: FutureBuilder<SetlistDetail>(
+        future: _setlistDetailAsync,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (snapshot.hasError) {
+            logError('Setlist detail fetch error: ${snapshot.error}');
+            return Center(
+              child: Icon(
+                Icons.error,
+                size: AppIconSizes.xxl,
+                color: Theme.of(context).colorScheme.error,
+              ),
+            );
+          }
+
+          final (setlist, event, stage) = snapshot.data!;
+          logInfo('Showing setlist detail: ${setlist.id}');
+
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(AppSpacing.medium),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              spacing: AppSpacing.large,
+              children: [
+                // イベント情報カード
+                _EventInfoCard(event: event, stage: stage),
+
+                // セットリスト
+                _MusicListWidget(musicIds: setlist.musicIds),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// イベント情報カードWidget
+class _EventInfoCard extends StatelessWidget {
+  const _EventInfoCard({
+    required Event event,
+    Stage? stage,
+  }) : _event = event,
+       _stage = stage;
+
+  final Event _event;
+  final Stage? _stage;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.medium),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          spacing: AppSpacing.small,
+          children: [
+            _ContentHeader(
+              leading: Icon(
+                Icons.event,
+                size: AppIconSizes.medium,
+                color: Theme.of(context).colorScheme.primary,
+              ),
+              title: Text(
+                t.setlist.detail.eventInfo,
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+            ),
+            const Divider(),
+            _InfoRow(
+              label: t.setlist.detail.eventTitle,
+              value: _event.title,
+            ),
+            _InfoRow(
+              label: t.setlist.date,
+              value: _event.date.toString().split(' ')[0],
+            ),
+            if (_stage != null)
+              _InfoRow(
+                label: t.setlist.detail.venue,
+                value: _stage.title,
+              ),
+            if (_event.order != null)
+              _InfoRow(
+                label: t.setlist.detail.eventOrder,
+                value: _event.order.toString(),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// 情報行Widget
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({
+    required String label,
+    required String value,
+  }) : _label = label,
+       _value = value;
+
+  final String _label;
+  final String _value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
+          child: Text(
+            _label,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+        Expanded(
+          flex: 9,
+          child: Text(
+            _value,
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// 音楽リストWidget
+class _MusicListWidget extends ConsumerWidget with LoggerMixin {
+  const _MusicListWidget({
+    required List<String> musicIds,
+  }) : _musicIds = musicIds;
+
+  final List<String> _musicIds;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (_musicIds.isEmpty) {
+      return Card(
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.large),
+          child: Center(
+            child: Column(
+              spacing: AppSpacing.medium,
+              children: [
+                Icon(
+                  Icons.library_music,
+                  size: AppIconSizes.xxl,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+                Text(
+                  t.setlist.empty.noSetlist,
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    return Card(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(AppSpacing.medium),
+            child: _ContentHeader(
+              leading: Icon(
+                Icons.library_music,
+                size: AppIconSizes.medium,
+                color: Theme.of(context).colorScheme.primary,
+              ),
+              title: Text(
+                t.setlist.detail.musicList,
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              trailing: Chip(
+                label: Text(
+                  t.setlist.detail.musicCount(count: _musicIds.length),
+                ),
+                backgroundColor: Theme.of(
+                  context,
+                ).colorScheme.primaryContainer,
+              ),
+            ),
+          ),
+          const Divider(height: 1),
+          _OrderedMusicList(musicIds: _musicIds),
+        ],
+      ),
+    );
+  }
+}
+
+class _ContentHeader extends StatelessWidget {
+  const _ContentHeader({
+    required Widget title,
+    Widget? leading,
+    Widget? trailing,
+    EdgeInsets padding = const EdgeInsets.symmetric(
+      vertical: AppSpacing.extraSmall,
+    ),
+  }) : _title = title,
+       _leading = leading,
+       _trailing = trailing,
+       _padding = padding;
+
+  final Widget _title;
+  final Widget? _leading;
+  final Widget? _trailing;
+  final EdgeInsets _padding;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: _padding,
+      child: ListTile(
+        leading: _leading,
+        title: _title,
+        trailing: _trailing,
+        contentPadding: EdgeInsets.zero,
+      ),
+    );
+  }
+}
+
+/// 順序付き音楽リストWidget
+class _OrderedMusicList extends ConsumerWidget with LoggerMixin {
+  const _OrderedMusicList({
+    required List<String> musicIds,
+  }) : _musicIds = musicIds;
+
+  final List<String> _musicIds;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return FutureBuilder<List<Music>>(
+      future: ref
+          .read(musicRepositoryProvider.notifier)
+          .getByMusicIds(_musicIds),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Padding(
+            padding: EdgeInsets.all(AppSpacing.large),
+            child: Center(child: CircularProgressIndicator()),
+          );
+        }
+
+        if (snapshot.hasError) {
+          logError('Music data fetch error: ${snapshot.error}');
+          return Center(
+            child: Text(
+              '${t.setlist.error.dataFetchFailed}: ${snapshot.error}',
+              style: TextStyle(color: Theme.of(context).colorScheme.error),
+            ),
+          );
+        }
+
+        final musics = snapshot.data!;
+        if (musics.isEmpty) {
+          return Padding(
+            padding: const EdgeInsets.all(AppSpacing.large),
+            child: Center(
+              child: Text(
+                t.setlist.empty.noSetlist,
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+            ),
+          );
+        }
+
+        // musicIdsの順序でソート
+        final orderedMusics = <Music>[];
+        for (final musicId in _musicIds) {
+          final music = musics.where((m) => m.id == musicId).firstOrNull;
+          if (music != null) {
+            orderedMusics.add(music);
+          }
+        }
+
+        return ListView.builder(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          itemCount: orderedMusics.length,
+
+          itemBuilder: (context, index) {
+            final music = orderedMusics[index];
+
+            return ListTile(
+              contentPadding: const EdgeInsets.all(AppSpacing.small),
+              leading: ClipRRect(
+                borderRadius: BorderRadius.circular(AppBorderRadius.medium),
+                child: Image.network(
+                  music.thumbnailUrl,
+                  fit: BoxFit.cover,
+                  loadingBuilder: (context, child, loadingProgress) =>
+                      loadingProgress == null
+                      ? child
+                      : const Center(child: CircularProgressIndicator()),
+                  errorBuilder: (context, error, stackTrace) => DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: Theme.of(
+                        context,
+                      ).colorScheme.surfaceContainerHighest,
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                    child: Icon(
+                      Icons.music_note,
+                      size: AppIconSizes.extraLarge,
+                      color: Theme.of(
+                        context,
+                      ).colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+              ),
+              title: Text(
+                music.title,
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+              subtitle: Text(
+                t.setlist.detail.musicNumber(number: index + 1),
+                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  fontWeight: FontWeight.w100,
+                ),
+              ),
+              trailing: const Icon(
+                Icons.arrow_forward_ios,
+                size: AppIconSizes.small,
+              ),
+              onTap: () => MusicDetailRoute(musicId: music.id).go(context),
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/app/lib/pages/setlist_detail_page.dart
+++ b/app/lib/pages/setlist_detail_page.dart
@@ -116,50 +116,44 @@ class _EventInfoCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(AppSpacing.medium),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          spacing: AppSpacing.small,
-          children: [
-            _ContentHeader(
-              leading: Icon(
-                Icons.event,
-                size: AppIconSizes.medium,
-                color: Theme.of(context).colorScheme.primary,
-              ),
-              title: Text(
-                t.setlist.detail.eventInfo,
-                style: Theme.of(context).textTheme.titleMedium,
-              ),
-              trailing: ShareButton(
-                url:
-                    'https://r0227n.github.io/xinxin_setlist/#/setlist/${_event.id}',
-              ),
-            ),
-            const Divider(),
-            _InfoRow(
-              label: t.setlist.detail.eventTitle,
-              value: _event.title,
-            ),
-            _InfoRow(
-              label: t.setlist.date,
-              value: _event.date.toString().split(' ')[0],
-            ),
-            if (_stage != null)
-              _InfoRow(
-                label: t.setlist.detail.venue,
-                value: _stage.title,
-              ),
-            if (_event.order != null)
-              _InfoRow(
-                label: t.setlist.detail.eventOrder,
-                value: _event.order.toString(),
-              ),
-          ],
+    return _ContentCard(
+      children: [
+        _ContentHeader(
+          leading: Icon(
+            Icons.event,
+            size: AppIconSizes.medium,
+            color: Theme.of(context).colorScheme.primary,
+          ),
+          title: Text(
+            t.setlist.detail.eventInfo,
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          trailing: ShareButton(
+            tooltip: t.share,
+            url:
+                'https://r0227n.github.io/xinxin_setlist/#/setlist/${_event.id}',
+          ),
         ),
-      ),
+        const Divider(),
+        _InfoRow(
+          label: t.setlist.detail.eventTitle,
+          value: _event.title,
+        ),
+        _InfoRow(
+          label: t.setlist.date,
+          value: _event.date.toString().split(' ')[0],
+        ),
+        if (_stage != null)
+          _InfoRow(
+            label: t.setlist.detail.venue,
+            value: _stage.title,
+          ),
+        if (_event.order != null)
+          _InfoRow(
+            label: t.setlist.detail.eventOrder,
+            value: _event.order.toString(),
+          ),
+      ],
     );
   }
 }
@@ -234,35 +228,51 @@ class _MusicListWidget extends ConsumerWidget with LoggerMixin {
       );
     }
 
-    return Card(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Padding(
-            padding: const EdgeInsets.all(AppSpacing.medium),
-            child: _ContentHeader(
-              leading: Icon(
-                Icons.library_music,
-                size: AppIconSizes.medium,
-                color: Theme.of(context).colorScheme.primary,
-              ),
-              title: Text(
-                t.setlist.detail.musicList,
-                style: Theme.of(context).textTheme.titleMedium,
-              ),
-              trailing: Chip(
-                label: Text(
-                  t.setlist.detail.musicCount(count: _musicIds.length),
-                ),
-                backgroundColor: Theme.of(
-                  context,
-                ).colorScheme.primaryContainer,
-              ),
-            ),
+    return _ContentCard(
+      children: [
+        _ContentHeader(
+          leading: Icon(
+            Icons.library_music,
+            size: AppIconSizes.medium,
+            color: Theme.of(context).colorScheme.primary,
           ),
-          const Divider(height: 1),
-          _OrderedMusicList(musicIds: _musicIds),
-        ],
+          title: Text(
+            t.setlist.detail.musicList,
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          trailing: Chip(
+            label: Text(
+              t.setlist.detail.musicCount(count: _musicIds.length),
+            ),
+            backgroundColor: Theme.of(
+              context,
+            ).colorScheme.primaryContainer,
+          ),
+        ),
+        const Divider(),
+        _OrderedMusicList(musicIds: _musicIds),
+      ],
+    );
+  }
+}
+
+class _ContentCard extends StatelessWidget {
+  const _ContentCard({
+    required List<Widget> children,
+  }) : _children = children;
+
+  final List<Widget> _children;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.medium),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          spacing: AppSpacing.small,
+          children: _children,
+        ),
       ),
     );
   }
@@ -363,7 +373,7 @@ class _OrderedMusicList extends ConsumerWidget with LoggerMixin {
             final music = orderedMusics[index];
 
             return ListTile(
-              contentPadding: const EdgeInsets.all(AppSpacing.small),
+              contentPadding: const EdgeInsets.all(AppSpacing.extraSmall),
               leading: ClipRRect(
                 borderRadius: BorderRadius.circular(AppBorderRadius.medium),
                 child: Image.network(

--- a/app/lib/pages/setlist_detail_page.dart
+++ b/app/lib/pages/setlist_detail_page.dart
@@ -3,6 +3,7 @@ import 'package:app/data/repositories/music_repository.dart';
 import 'package:app/data/repositories/stage_repository.dart';
 import 'package:app/data/services/setlist_service.dart';
 import 'package:app/i18n/translations.g.dart';
+import 'package:app/pages/widgets/share_button.dart';
 import 'package:app/router/routes.dart';
 import 'package:app_logger/app_logger.dart';
 import 'package:app_preferences/app_preferences.dart';
@@ -131,6 +132,10 @@ class _EventInfoCard extends StatelessWidget {
               title: Text(
                 t.setlist.detail.eventInfo,
                 style: Theme.of(context).textTheme.titleMedium,
+              ),
+              trailing: ShareButton(
+                url:
+                    'https://r0227n.github.io/xinxin_setlist/#/setlist/${_event.id}',
               ),
             ),
             const Divider(),

--- a/app/lib/pages/setlist_page.dart
+++ b/app/lib/pages/setlist_page.dart
@@ -292,38 +292,9 @@ class _SetlistTile extends ConsumerWidget with LoggerMixin {
             ),
             trailing: const Icon(Icons.arrow_forward_ios),
             isThreeLine: true,
-            onTap: () async {
-              logInfo('セットリスト詳細をダイアログ表示: ${setlist.id}');
-
-              // TODO: セットリスト詳細画面作成後、遷移するように書き換える
-              // 現状仮置きとして、ダイアログで表示する
-              final musics = await ref
-                  .read(musicRepositoryProvider.notifier)
-                  .getByMusicIds(setlist.musicIds);
-              if (musics.isEmpty || !context.mounted) {
-                return;
-              }
-              await showDialog<void>(
-                context: context,
-                builder: (context) => AlertDialog(
-                  title: Text(event.title),
-                  content: SingleChildScrollView(
-                    child: ListBody(
-                      children: [
-                        for (var index = 0; index < musics.length; index++) ...[
-                          Text('${index + 1}. ${musics[index].title}'),
-                        ],
-                      ],
-                    ),
-                  ),
-                  actions: [
-                    TextButton(
-                      onPressed: () => Navigator.of(context).pop(),
-                      child: Text(t.dialog.close),
-                    ),
-                  ],
-                ),
-              );
+            onTap: () {
+              logInfo('セットリスト詳細へ遷移: ${setlist.id}');
+              SetlistDetailRoute(eventId: setlist.eventId).go(context);
             },
           );
         }(),

--- a/app/lib/router/routes.dart
+++ b/app/lib/router/routes.dart
@@ -1,4 +1,5 @@
 import 'package:app/pages/music_detail_page.dart';
+import 'package:app/pages/setlist_detail_page.dart';
 import 'package:app/pages/setlist_page.dart';
 import 'package:app/pages/settings/custom_license_page.dart';
 import 'package:app/pages/settings/settings_page.dart';
@@ -57,7 +58,7 @@ class SetlistDetailRoute extends GoRouteData with _$SetlistDetailRoute {
 
   @override
   Widget build(BuildContext context, GoRouterState state) {
-    return SetlistPage(eventId: eventId);
+    return SetlistDetailPage(eventId: eventId);
   }
 }
 


### PR DESCRIPTION
## 📝 概要

<!-- このPRで何を実装したか、簡潔に教えてください -->

## 🔄 変更内容

<!-- どんな変更を行ったか、箇条書きで記載してください -->

-
-
-

## 🔗 関連Issue

- Closes #<!-- Issue番号があれば記載 -->

## ✅ 基本チェック

### 動作確認

- [ ] 機能が期待通り動作する
- [ ] エラーが発生しない
- [ ] 既存機能に影響がない

### コード品質

- [ ] `melos run analyze` でエラーなし
- [ ] `melos run format` を実行済み
- [ ] テストを追加・更新（必要に応じて）

## 📱 テスト結果

<!-- 実際にテストした内容を記載してください -->

- [ ] iOSで動作確認
- [ ] Androidで動作確認

## 🖼️ スクリーンショット（UI変更がある場合）

<!-- 変更前後の画面があれば貼り付けてください -->

## 💬 レビュアーへのメモ

<!-- 特に見てほしいポイントや注意事項があれば記載してください -->

---

**🚀 Ready for review!**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - セットリスト詳細画面を追加。イベント情報（タイトル・日付・会場・開催順）と曲リストを表示。曲数/曲番号の表記、サムネイル表示、タップで楽曲詳細へ遷移、共有ボタンを提供。
- 変更
  - セットリスト一覧のタップ時、ダイアログ表示から専用の詳細画面への遷移に変更し、閲覧体験を改善。
- 多言語対応
  - 日英で「setlist.detail」文言を追加（タイトル、イベント情報、イベント名、開催順、会場、曲リスト、曲番号・曲数のプレースホルダー対応）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->