### PR TITLE
GitHub Pages buildパイプラインをリファクタリング

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -2,7 +2,8 @@ name: Deploy to GitHub Pages
 
 on:
   pull_request:
-    types: [closed]
+    types:
+      - closed
     branches:
       - main
 
@@ -12,6 +13,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-24.04
     defaults:
       run:

--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -5,7 +5,6 @@ on:
     types: [closed]
     branches:
       - main
-  workflow_dispatch:
 
 concurrency:
   group: deploy-github-pages-${{ github.ref }}

--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -5,13 +5,7 @@ on:
     types: [closed]
     branches:
       - main
-      - develop
   workflow_dispatch:
-
-permissions:
-  contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: deploy-github-pages-${{ github.ref }}
@@ -19,7 +13,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: ./app
@@ -61,10 +55,13 @@ jobs:
           path: './app/build/web'
 
   deploy:
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
## 📝 概要

- workflow_dispatch(手動実行)を削除
- permissionをdeployのみにする

を実行し、ビルドパイプラインをリファクタリング
<!-- このPRで何を実装したか、簡潔に教えてください -->

## 🔄 変更内容

<!-- どんな変更を行ったか、箇条書きで記載してください -->

-
-
-

## 🔗 関連Issue

- Closes #<!-- Issue番号があれば記載 -->

## ✅ 基本チェック

### 動作確認

- [ ] 機能が期待通り動作する
- [ ] エラーが発生しない
- [ ] 既存機能に影響がない

### コード品質

- [ ] `melos run analyze` でエラーなし
- [ ] `melos run format` を実行済み
- [ ] テストを追加・更新（必要に応じて）

## 📱 テスト結果

<!-- 実際にテストした内容を記載してください -->

- [ ] iOSで動作確認
- [ ] Androidで動作確認

## 🖼️ スクリーンショット（UI変更がある場合）

<!-- 変更前後の画面があれば貼り付けてください -->

## 💬 レビュアーへのメモ

<!-- 特に見てほしいポイントや注意事項があれば記載してください -->

---

**🚀 Ready for review!**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Pages のデプロイワークフローを更新。
  * 対象ブランチを main のみに統一。
  * 手動実行トリガーを廃止。
  * 実行環境を Ubuntu 24.04 に固定。
  * 権限設定をジョブ単位に見直し。
  * これによりデプロイ挙動の一貫性が向上し、不要な実行が減少します。公開サイトの機能や表示に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->